### PR TITLE
Reorder node-redis client args.  Use hmset for setting cache items.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,9 @@ const Logger = require('koop-logger')
 const log = new Logger()
 const config = require('config')
 
+// Convenience to make callbacks optional in most functions
+function noop () {}
+
 function Cache (options = {}) {
   const host = options.host || config.cache.redis.host
   this.client = this.catalog.client = redis.createClient(host)
@@ -19,6 +22,10 @@ function Cache (options = {}) {
   this.catalog.set = this.set
   this.catalog.get = this.get
 }
+
+Cache.name = 'Redis Cache'
+Cache.type = 'cache'
+Cache.version = require('../package.json').version
 
 Cache.prototype.disconnect = function () {
   this.client.quit()
@@ -34,14 +41,10 @@ Cache.prototype.get = function (field, key, callback) {
   })
 }
 
-Cache.name = 'Redis Cache'
-Cache.type = 'cache'
-Cache.version = require('../package.json').version
-
 Util.inherits(Cache, EventEmitter)
 
-Cache.prototype.insert = function (key, geojson, options = {}, callback) {
-  if (!callback) {
+Cache.prototype.insert = function (key, geojson, options = {}, callback = noop) {
+  if (typeof options === 'function') {
     callback = options
     options = {}
   }
@@ -60,8 +63,8 @@ Cache.prototype.insert = function (key, geojson, options = {}, callback) {
   })
 }
 
-Cache.prototype.upsert = function (key, geojson, options = {}, callback) {
-  if (!callback) {
+Cache.prototype.upsert = function (key, geojson, options = {}, callback = noop) {
+  if (typeof options === 'function') {
     callback = options
     options = {}
   }
@@ -76,8 +79,8 @@ Cache.prototype.upsert = function (key, geojson, options = {}, callback) {
   })
 }
 
-Cache.prototype.update = function (key, geojson, options = {}, callback) {
-  if (!callback) {
+Cache.prototype.update = function (key, geojson, options = {}, callback = noop) {
+  if (typeof options === 'function') {
     callback = options
     options = {}
   }
@@ -98,9 +101,8 @@ Cache.prototype.update = function (key, geojson, options = {}, callback) {
   })
 }
 
-Cache.prototype.append = function (key, geojson, options = {}, callback) {
-  // TODO use lists instead of hash keys
-  if (!callback) {
+Cache.prototype.append = function (key, geojson, options = {}, callback = noop) {
+  if (typeof options === 'function') {
     callback = options
     options = {}
   }
@@ -114,9 +116,8 @@ Cache.prototype.append = function (key, geojson, options = {}, callback) {
   })
 }
 
-Cache.prototype.retrieve = function (key, options, callback) {
-  // TODO use promise.all
-  if (!callback) {
+Cache.prototype.retrieve = function (key, options, callback = noop) {
+  if (typeof options === 'function') {
     callback = options
     options = {}
   }

--- a/test/index.js
+++ b/test/index.js
@@ -148,6 +148,29 @@ test('Trying to delete the catalog entry when something is still in the cache', 
   })
 })
 
+test('Ensure multiple entries are hashed properly', t => {
+  cache.insert('key7', geojson, {}, e => {
+    t.error(e, 'no error in callback')
+    const geojson2 = _.cloneDeep(geojson)
+    geojson2.features[0].properties.key = 'test2'
+    geojson2.metadata.name = 'Test2'
+    cache.insert('key8', geojson2, {}, e => {
+      t.error(e, 'no error in callback')
+      cache.retrieve('key8', (e, cached) => {
+        t.error(e, 'no error in callback')
+        t.equals(cached.metadata.name, 'Test2')
+        t.equal(cached.features[0].properties.key, 'test2', 'retrieved only new features')
+        cache.retrieve('key7', (e, cached) => {
+          t.error(e, 'no error in callback')
+          t.equals(cached.metadata.name, 'Test')
+          t.equal(cached.features[0].properties.key, 'value', 'retrieved only new features')
+          t.end()
+        })
+      })
+    })
+  })
+})
+
 test('teardown', t => {
   cache.disconnect()
   t.pass('disconnected')


### PR DESCRIPTION
This PR makes the following changes:

1) The calls to the node-redis client hash methods had been being called in the order of `field, key, callback`.  However, the node-redis [docs](https://github.com/NodeRedis/node_redis#usage-example) shows that the parameter order needs to be, generally,`key, field, callback`.  So I have fixed the parameter order.
**UPDATE**: I believe the old unit test code was missing this because we didn't have a test that did multiple inserts and retrieves with different keys.  The old code was using `field` value as a key, so only a test with multiple inserts would have illustrated a problem.
 
2) I switched to using `hmset` method for hash sets to solve the  `wrong number of arguments` error 
 received when setting additional fields for an existing key.  Note that this error appears to only occur in some environments (e.g. Azure Redis), so existing unit tests did not catch.  New code should be more robust.

**UPDATE 2**
3) Reworked the handling of `options` and `callback` handling in prototype methods.  Existing handling failed when the method was executed with an `options` argument, but no `callback` argument.  In that situation, the options object was being reset to `{}`.
